### PR TITLE
addNewContact with rotation, add tools/scenario scripts 

### DIFF
--- a/idl/hpp/corbaserver/rbprm/rbprmbuilder.idl
+++ b/idl/hpp/corbaserver/rbprm/rbprmbuilder.idl
@@ -778,8 +778,9 @@ module hpp
     /// \param max_num_sample number of times it will try to randomly sample a configuration before failing
     /// \param lockOtherJoints : if True, the values of all the joints exepct the ones of 'limbName' are constrained to be constant.
     ///                           This only affect the first projection, if max_num_sample > 0 and the first projection was unsuccessfull, the parameter is ignored
+    /// \param rotation : desired rotation of the end-effector in contact, expressed as Quaternion (x,y,z,w). If different from zero, the normal is ignored. Otherwise the rotation is automatically computed from the normal (with one axis of freedom)
     /// \return (success,NState) whether the creation was successful, as well as the new state
-    short addNewContact(in unsigned short stateId, in string limbName, in floatSeq position, in floatSeq normal, in unsigned short max_num_sample, in boolean lockOtherJoints) raises (Error);
+    short addNewContact(in unsigned short stateId, in string limbName, in floatSeq position, in floatSeq normal, in unsigned short max_num_sample, in boolean lockOtherJoints,in floatSeq rotation) raises (Error);
 
     /// removes a contact from the state
     /// if the limb is not already in contact, does nothing

--- a/script/scenarios/demos/talos_plateformes.py
+++ b/script/scenarios/demos/talos_plateformes.py
@@ -6,7 +6,7 @@ print "Plan guide trajectory ..."
 import talos_plateformes_path as tp
 print "Done."
 import time
-
+Robot.urdfSuffix+="_safeFeet"
 pId = tp.ps.numberPaths() -1
 fullBody = Robot ()
 

--- a/script/scenarios/sandbox/ANYmal/anymal_flatGround_path.py
+++ b/script/scenarios/sandbox/ANYmal/anymal_flatGround_path.py
@@ -36,7 +36,7 @@ ps = ProblemSolver( rbprmBuilder )
 ps.setParameter("Kinodynamic/velocityBound",vMax)
 ps.setParameter("Kinodynamic/accelerationBound",aMax)
 # force the orientation of the trunk to match the direction of the motion
-ps.setParameter("Kinodynamic/forceOrientation",True)
+ps.setParameter("Kinodynamic/forceAllOrientation",True)
 ps.setParameter("DynamicPlanner/sizeFootX",0.01)
 ps.setParameter("DynamicPlanner/sizeFootY",0.01)
 ps.setParameter("DynamicPlanner/friction",mu)

--- a/script/scenarios/sandbox/ANYmal/anymal_modular_palet_low.py
+++ b/script/scenarios/sandbox/ANYmal/anymal_modular_palet_low.py
@@ -1,0 +1,145 @@
+from hpp.corbaserver.rbprm.anymal import Robot
+from hpp.gepetto import Viewer
+from tools.display_tools import *
+import time
+print "Plan guide trajectory ..."
+import scenarios.sandbox.ANYmal.anymal_modular_palet_low_path as tp
+#Robot.urdfSuffix += "_safeFeet"
+statusFilename = tp.statusFilename
+pId = tp.pid
+f = open(statusFilename,"a")
+if tp.ps.numberPaths() > 0 :
+  print "Path planning OK."
+  f.write("Planning_success: True"+"\n")
+  f.close()
+else :
+  print "Error during path planning"
+  f.write("Planning_success: False"+"\n")
+  f.close()
+  import sys
+  sys.exit(1)
+
+fullBody = Robot ()
+
+# Set the bounds for the root
+rootBounds = tp.rootBounds[::]
+
+rootBounds[0] -= 0.2
+rootBounds[1] += 0.2
+rootBounds[2] -= 0.5
+rootBounds[3] += 0.5
+rootBounds[4] -= 0.2
+rootBounds[5] += 0.2
+fullBody.setJointBounds ("root_joint",  rootBounds)
+fullBody.setVeryConstrainedJointsBounds()
+
+# add the 6 extraDof for velocity and acceleration (see *_path.py script)
+fullBody.client.robot.setDimensionExtraConfigSpace(tp.extraDof)
+fullBody.client.robot.setExtraConfigSpaceBounds([-tp.vMax,tp.vMax,-tp.vMax,tp.vMax,-tp.vMax,tp.vMax,-tp.aMax,tp.aMax,-tp.aMax,tp.aMax,-tp.aMaxZ,tp.aMaxZ])
+ps = tp.ProblemSolver( fullBody )
+ps.setParameter("Kinodynamic/velocityBound",tp.vMax)
+ps.setParameter("Kinodynamic/accelerationBound",tp.aMax)
+ps.setParameter("FullBody/frictionCoefficient",tp.mu)
+#load the viewer
+try :
+    v = tp.Viewer (ps,viewerClient=tp.v.client, displayCoM = True)
+except Exception:
+    print "No viewer started !"
+    class FakeViewer():
+        def __init__(self):
+            return
+        def __call__(self,q):
+            return
+        def addLandmark(self,a,b):
+            return
+    v = FakeViewer()
+
+
+# load a reference configuration
+q_ref = fullBody.referenceConfig[::]+[0]*6
+q_init = q_ref[::]
+fullBody.setReferenceConfig(q_ref)
+fullBody.setPostureWeights(fullBody.postureWeights[::]+[0]*6)
+#fullBody.usePosturalTaskContactCreation(True)
+
+fullBody.setCurrentConfig (q_init)
+
+print "Generate limb DB ..."
+tStart = time.time()
+# generate databases : 
+
+fullBody.loadAllLimbs("static","ReferenceConfiguration",nbSamples=100000)
+tGenerate =  time.time() - tStart
+print "Done."
+print "Databases generated in : "+str(tGenerate)+" s"
+v.addLandmark('anymal/base_0',0.2)
+
+#define initial and final configurations : 
+configSize = fullBody.getConfigSize() -fullBody.client.robot.getDimensionExtraConfigSpace()
+
+q_init[0:7] = tp.ps.configAtParam(pId,0)[0:7] # use this to get the correct orientation
+q_goal = q_init[::]; q_goal[0:7] = tp.ps.configAtParam(pId,tp.ps.pathLength(pId))[0:7]
+vel_init = tp.ps.configAtParam(pId,0)[tp.indexECS:tp.indexECS+3]
+acc_init = tp.ps.configAtParam(pId,0)[tp.indexECS+3:tp.indexECS+6]
+vel_goal = tp.ps.configAtParam(pId,tp.ps.pathLength(pId))[tp.indexECS:tp.indexECS+3]
+acc_goal = [0,0,0]
+
+robTreshold = 2
+# copy extraconfig for start and init configurations
+q_init[configSize:configSize+3] = vel_init[::]
+q_init[configSize+3:configSize+6] = acc_init[::]
+q_goal[configSize:configSize+3] = vel_goal[::]
+q_goal[configSize+3:configSize+6] = [0,0,0]
+
+
+q_init[2] = q_ref[2]
+q_goal[2] = q_ref[2]
+
+normals = [[0.,0.,1.] for _ in range(4)]
+fullBody.setStaticStability(True)
+fullBody.setCurrentConfig (q_init)
+v(q_init)
+fullBody.setStartState(q_init,Robot.limbs_names,normals)
+fullBody.setEndState(q_goal,Robot.limbs_names,normals)
+
+fullBody.setCurrentConfig (q_goal)
+v(q_goal)
+
+
+print "Generate contact plan ..."
+tStart = time.time()
+configs = fullBody.interpolate(0.001,pathId=pId,robustnessTreshold = robTreshold, filterStates = True,testReachability=True,quasiStatic=True)
+tInterpolateConfigs = time.time() - tStart
+print "Done."
+print "Contact plan generated in : "+str(tInterpolateConfigs)+" s"
+print "number of configs :", len(configs)
+#raw_input("Press Enter to display the contact sequence ...")
+#displayContactSequence(v,configs)
+
+if len(configs) < 2 :
+  cg_success = False
+  print "Error during contact generation."
+else:
+  cg_success = True
+  print "Contact generation Done."
+if abs(configs[-1][0] - tp.q_goal[0]) < 0.01 and abs(configs[-1][1]- tp.q_goal[1]) < 0.01  and (len(fullBody.getContactsVariations(len(configs)-2,len(configs)-1))==1):
+  print "Contact generation successful."
+  cg_reach_goal = True
+else:
+  print "Contact generation failed to reach the goal."
+  cg_reach_goal = False
+
+f = open(statusFilename,"a")
+f.write("cg_success: "+str(cg_success)+"\n")
+f.write("cg_reach_goal: "+str(cg_reach_goal)+"\n")
+f.close()
+
+if (not cg_success):
+  import sys
+  sys.exit(1)
+
+#beginId = 2
+
+# put back original bounds for wholebody methods
+fullBody.resetJointsBounds()
+#displayContactSequence(v,configs)

--- a/script/scenarios/sandbox/ANYmal/anymal_modular_palet_low.py
+++ b/script/scenarios/sandbox/ANYmal/anymal_modular_palet_low.py
@@ -4,6 +4,7 @@ from tools.display_tools import *
 import time
 print "Plan guide trajectory ..."
 import scenarios.sandbox.ANYmal.anymal_modular_palet_low_path as tp
+
 #Robot.urdfSuffix += "_safeFeet"
 statusFilename = tp.statusFilename
 pId = tp.pid
@@ -68,7 +69,7 @@ print "Generate limb DB ..."
 tStart = time.time()
 # generate databases : 
 
-fullBody.loadAllLimbs("static","ReferenceConfiguration",nbSamples=100000)
+fullBody.loadAllLimbs("static","ReferenceConfiguration",nbSamples=100000,disableEffectorCollision=False)
 tGenerate =  time.time() - tStart
 print "Done."
 print "Databases generated in : "+str(tGenerate)+" s"
@@ -83,8 +84,8 @@ vel_init = tp.ps.configAtParam(pId,0)[tp.indexECS:tp.indexECS+3]
 acc_init = tp.ps.configAtParam(pId,0)[tp.indexECS+3:tp.indexECS+6]
 vel_goal = tp.ps.configAtParam(pId,tp.ps.pathLength(pId))[tp.indexECS:tp.indexECS+3]
 acc_goal = [0,0,0]
-
-robTreshold = 2
+vel_init = [0,0,0]
+robTreshold = 5
 # copy extraconfig for start and init configurations
 q_init[configSize:configSize+3] = vel_init[::]
 q_init[configSize+3:configSize+6] = acc_init[::]

--- a/script/scenarios/sandbox/ANYmal/anymal_modular_palet_low_path.py
+++ b/script/scenarios/sandbox/ANYmal/anymal_modular_palet_low_path.py
@@ -1,0 +1,135 @@
+from hpp.corbaserver.rbprm.anymal_abstract import Robot
+Robot.urdfName += "_large"
+from hpp.gepetto import Viewer
+from hpp.corbaserver import ProblemSolver
+from pinocchio import Quaternion
+import numpy as np
+import time
+import math
+statusFilename = "/res/infos.log"
+
+Z_VALUE = 0.465
+Y_VALUE = -0.1
+vInit = 0.3
+vMax = 0.5# linear velocity bound for the root
+aMax = 0.5# linear acceleration bound for the root
+aMaxZ = 5.
+extraDof = 6
+mu=0.3# coefficient of friction
+# Creating an instance of the helper class, and loading the robot
+# Creating an instance of the helper class, and loading the robot
+rbprmBuilder = Robot ()
+# Define bounds for the root : bounding box of the scenario
+rootBounds = [-1.7,1.7, Y_VALUE-0.001, Y_VALUE+0.001, Z_VALUE-0.001, Z_VALUE+0.231]
+rbprmBuilder.setJointBounds ("root_joint", rootBounds)
+
+# The following lines set constraint on the valid configurations:
+# a configuration is valid only if all limbs can create a contact with the corresponding afforcances type
+rbprmBuilder.setFilter(Robot.urdfNameRom)
+for rom in rbprmBuilder.urdfNameRom :
+    rbprmBuilder.setAffordanceFilter(rom, ['Support'])
+
+# We also bound the rotations of the torso. (z, y, x)
+rbprmBuilder.boundSO3([-3.14,3.14,-0.1,0.1,-0.1,0.1])
+# Add 6 extraDOF to the problem, used to store the linear velocity and acceleration of the root
+rbprmBuilder.client.robot.setDimensionExtraConfigSpace(extraDof)
+# We set the bounds of this extraDof with velocity and acceleration bounds (expect on z axis)
+rbprmBuilder.client.robot.setExtraConfigSpaceBounds([-vMax,vMax,-vMax,vMax,-vMax,vMax,-aMax,aMax,-aMax,aMax,-aMaxZ,aMaxZ])
+indexECS = rbprmBuilder.getConfigSize() - rbprmBuilder.client.robot.getDimensionExtraConfigSpace()
+
+# Creating an instance of HPP problem solver 
+ps = ProblemSolver( rbprmBuilder )
+# define parameters used by various methods : 
+ps.setParameter("Kinodynamic/velocityBound",vMax)
+ps.setParameter("Kinodynamic/accelerationBound",aMax)
+ps.setParameter("Kinodynamic/verticalAccelerationBound",aMaxZ)
+ps.setParameter("Kinodynamic/forceAllOrientation",True)
+ps.setParameter("DynamicPlanner/sizeFootX",0.2)
+ps.setParameter("DynamicPlanner/sizeFootY",0.12)
+ps.setParameter("DynamicPlanner/friction",mu)
+# sample only configuration with null velocity and acceleration :
+ps.setParameter("ConfigurationShooter/sampleExtraDOF",False)
+ps.setParameter("PathOptimization/RandomShortcut/NumberOfLoops",100)
+
+# initialize the viewer :
+from hpp.gepetto import ViewerFactory
+vf = ViewerFactory (ps)
+
+# load the module to analyse the environnement and compute the possible contact surfaces
+from hpp.corbaserver.affordance.affordance import AffordanceTool
+afftool = AffordanceTool ()
+afftool.setAffordanceConfig('Support', [0.5, 0.03, 0.00005])
+afftool.loadObstacleModel ("hpp_environments", "ori/modular_palet_low", "planning", vf, reduceSizes=[0.06,0,0])
+#afftool.loadObstacleModel ("hpp_environments", "ori/modular_palet_low", "planning", vf)
+try :
+    v = vf.createViewer(displayArrows = True)
+except Exception:
+    print "No viewer started !"
+    class FakeViewer():
+        def __init__(self):
+            return
+        def __call__(self,q):
+            return
+    v = FakeViewer()
+    
+#afftool.visualiseAffordances('Support', v, v.color.lightBrown)
+
+#v.addLandmark(v.sceneName,1)
+q_init = rbprmBuilder.getCurrentConfig ();
+
+
+q_init[2] = Z_VALUE
+q_init[0:2] = [-1.6,Y_VALUE]
+q_init[-6] = vInit
+v(q_init)
+
+q_goal=q_init[::]
+q_goal[0] = 1.6
+
+
+ps.setInitialConfig (q_init)
+ps.addGoalConfig (q_goal)
+
+# write problem in files : 
+f = open(statusFilename,"w")
+f.write("q_init= "+str(q_init)+"\n")
+f.write("q_goal= "+str(q_goal)+"\n")
+f.close()
+
+
+# Choosing RBPRM shooter and path validation methods.
+ps.selectConfigurationShooter("RbprmShooter")
+ps.selectPathValidation("RbprmPathValidation",0.05)
+# Choosing kinodynamic methods :
+ps.selectSteeringMethod("RBPRMKinodynamic")
+ps.selectDistance("Kinodynamic")
+ps.selectPathPlanner("DynamicPlanner")
+ps.addPathOptimizer ("RandomShortcutDynamic")
+
+
+# Solve the planning problem :
+t = ps.solve()
+print "Guide planning done in "+str(t)+", optimizing trajectory ..."
+pid = ps.numberPaths()-1
+
+for i in range(20):
+  ps.optimizePath(pid)
+  pid = ps.numberPaths()-1
+
+try :
+    # display solution : 
+    from hpp.gepetto import PathPlayer
+    pp = PathPlayer (v)
+    pp.dt=0.1
+    pp.displayPath(pid)#pp.displayVelocityPath(0) #
+    v.client.gui.setVisibility("path_"+str(pid)+"_root","ALWAYS_ON_TOP")
+    pp.dt=0.01
+    pp(pid)
+except Exception:
+    pass
+
+# move the robot out of the view before computing the contacts
+q_far = q_init[::]
+q_far[2] = -2
+v(q_far)
+

--- a/script/scenarios/sandbox/ANYmal/anymal_modular_palet_low_path.py
+++ b/script/scenarios/sandbox/ANYmal/anymal_modular_palet_low_path.py
@@ -6,7 +6,7 @@ from pinocchio import Quaternion
 import numpy as np
 import time
 import math
-statusFilename = "/res/infos.log"
+statusFilename = "infos.log"
 
 Z_VALUE = 0.465
 Y_VALUE = -0.1
@@ -59,7 +59,8 @@ vf = ViewerFactory (ps)
 from hpp.corbaserver.affordance.affordance import AffordanceTool
 afftool = AffordanceTool ()
 afftool.setAffordanceConfig('Support', [0.5, 0.03, 0.00005])
-afftool.loadObstacleModel ("hpp_environments", "ori/modular_palet_low", "planning", vf, reduceSizes=[0.06,0,0])
+afftool.setMinimumArea('Support',0.03)
+afftool.loadObstacleModel ("hpp_environments", "ori/modular_palet_low_collision", "planning", vf, reduceSizes=[0.1,0,0])
 #afftool.loadObstacleModel ("hpp_environments", "ori/modular_palet_low", "planning", vf)
 try :
     v = vf.createViewer(displayArrows = True)
@@ -72,7 +73,7 @@ except Exception:
             return
     v = FakeViewer()
     
-#afftool.visualiseAffordances('Support', v, v.color.lightBrown)
+afftool.visualiseAffordances('Support', v, v.color.lightBrown)
 
 #v.addLandmark(v.sceneName,1)
 q_init = rbprmBuilder.getCurrentConfig ();

--- a/script/scenarios/sandbox/anymal_one_step/anymal_box.py
+++ b/script/scenarios/sandbox/anymal_one_step/anymal_box.py
@@ -9,12 +9,12 @@ viewer = sos.v
 ### Go somewhere
 
 n_goal = q_init[:7][:]
-n_goal[0] += 3
+n_goal[0] += .5
 n_goal[1] += 0
 #~ n_goal[2] = [0.,0.,0.7071,0.7071]
-#~ n_goal[3:7] = [0.,0.,0.7071,0.7071]
+n_goal[3:7] = [0.,0.,0.7071,0.7071]
 #~ sos.fullBody.toggleNonContactingLimb(sos.fullBody.prongFrontId)
-states, configs = fsp.goToQuasiStatic(initState,n_goal, displayGuidePath = False)
+states, configs = fsp.goToQuasiStatic(initState,n_goal, stepsize = 0.001,  displayGuidePath = False, erasePreviousStates = True)
 #~ pId = fsp.guidePath(initState.q()[:7], n_goal, displayPath = True)
 #~ fsp.setPlanningContext()
 #~ fsp.pathPlayer(pId)
@@ -24,32 +24,37 @@ states, configs = fsp.goToQuasiStatic(initState,n_goal, displayGuidePath = False
 
 #display computed States:
 
-n_goal[3:7] = [0.,0.,0.7071,0.7071]
+#~ n_goal[3:7] = [0.,0.,0.7071,0.7071]
 
-s = states[-1] #last state computed
-states2, configs2 = fsp.goToQuasiStatic(s,n_goal, displayGuidePath = False)
+#~ s = states[-1] #last state computed
+#~ states, configs = fsp.goToQuasiStatic(s,n_goal, displayGuidePath = False, erasePreviousStates = True, stepsize = 0.001)
 
 #display configuration
-viewer(s.q())
+#~ viewer(s.q())
 
-states+=states2
-configs+=configs2
+#~ states+=states2
+#~ configs+=configs2
 
 configs = [q + [0. for _ in range(6)] for q in configs]
 
-sos.dispContactPlan(states,0.051) #2nd argument is frame rateue
+fullBody = sos.fullBody
+v = viewer
+
+#~ sos.dispContactPlan(states,0.051) #2nd argument is frame rateue
 
 #some helpers: 
-s.q() # configuration associated to state
+#~ s.q() # configuration associated to state
 #~ initState. # configuration associated to state
 
-from hpp.corbaserver.rbprm import rbprmstate
-target = sos.fullBody.getJointPosition(sos.fullBody.prongFrontId)[:3]
-target[2] = 0.
+#~ from hpp.corbaserver.rbprm import rbprmstate
+#~ target = sos.fullBody.getJointPosition(sos.fullBody.prongFrontId)[:3]
+#~ target[2] = 0.
 
 
-s = rbprmstate.StateHelper.cloneState(states[-1])[0]
-fb = sos.fullBody
+#~ s = rbprmstate.StateHelper.cloneState(states[-1])[0]
+#~ fb = sos.fullBody
 
 #~ sos.fullBody.toggleNonContactingLimb(sos.fullBody.prongFrontId)
 #~ rbprmstate.StateHelper.addNewContact(s,sos.fullBody.prongFrontId,target,[0.,0.,1.])
+fullBody.resetJointsBounds()
+

--- a/script/scenarios/sandbox/anymal_one_step/anymal_box.sh
+++ b/script/scenarios/sandbox/anymal_one_step/anymal_box.sh
@@ -1,0 +1,12 @@
+#! /bin/bash
+
+
+gepetto-gui &
+hpp-rbprm-server &
+cp *.py /media/data/dev/linux/hpp/src/hpp-rbprm-corba/script/scenarios/memmo
+#~ ipython -i --no-confirm-exit $DEVEL_HPP_DIR/src/multicontact-locomotion-planning/scripts/run_mlp.py talos_circle
+ipython -i --no-confirm-exit $DEVEL_HPP_DIR/src/multicontact-locomotion-planning/scripts/run_mlp.py anymal_box.py
+
+pkill -f  'gepetto-gui'
+pkill -f  'hpp-rbprm-server'
+

--- a/script/scenarios/sandbox/anymal_one_step/config.py
+++ b/script/scenarios/sandbox/anymal_one_step/config.py
@@ -1,4 +1,4 @@
-SCENE="multicontact/ground"
+SCENE="multicontact/anymal_box"
 INIT_CONFIG_ROOT =   [0,0,0.465,0,0,0,1]
 INIT_CONFIG_WB   =   None
 ROOT_BOUNDS      =  [-20,20, -20, 20, 0.1, 0.6]

--- a/script/scenarios/sandbox/talos_maze_path.py
+++ b/script/scenarios/sandbox/talos_maze_path.py
@@ -1,0 +1,106 @@
+from hpp.corbaserver.rbprm.talos_abstract import Robot
+from hpp.gepetto import Viewer
+from hpp.corbaserver import ProblemSolver
+import numpy as np
+from pinocchio import Quaternion
+import time
+
+Robot.urdfName += "_large"
+
+vMax = 0.5# linear velocity bound for the root
+aMax = 0.5# linear acceleration bound for the root
+extraDof = 6
+mu=0.5# coefficient of friction
+# Creating an instance of the helper class, and loading the robot
+# Creating an instance of the helper class, and loading the robot
+rbprmBuilder = Robot ()
+# Define bounds for the root : bounding box of the scenario
+rbprmBuilder.setJointBounds ("root_joint", [0,18.5, 0, 24., 0.98, 0.98])
+rbprmBuilder.setJointBounds ('torso_1_joint', [0,0])
+rbprmBuilder.setJointBounds ('torso_2_joint', [0,0])
+
+
+# The following lines set constraint on the valid configurations:
+# a configuration is valid only if all limbs can create a contact with the corresponding afforcances type
+rbprmBuilder.setFilter(['talos_lleg_rom','talos_rleg_rom'])
+rbprmBuilder.setAffordanceFilter('talos_lleg_rom', ['Support',])
+rbprmBuilder.setAffordanceFilter('talos_rleg_rom', ['Support'])
+# We also bound the rotations of the torso. (z, y, x)
+rbprmBuilder.boundSO3([-4,4,-0.1,0.1,-0.1,0.1])
+# Add 6 extraDOF to the problem, used to store the linear velocity and acceleration of the root
+rbprmBuilder.client.robot.setDimensionExtraConfigSpace(extraDof)
+# We set the bounds of this extraDof with velocity and acceleration bounds (expect on z axis)
+rbprmBuilder.client.robot.setExtraConfigSpaceBounds([-vMax,vMax,-vMax,vMax,0,0,-aMax,aMax,-aMax,aMax,0,0])
+indexECS = rbprmBuilder.getConfigSize() - rbprmBuilder.client.robot.getDimensionExtraConfigSpace()
+
+# Creating an instance of HPP problem solver 
+ps = ProblemSolver( rbprmBuilder )
+# define parameters used by various methods : 
+ps.setParameter("Kinodynamic/velocityBound",vMax)
+ps.setParameter("Kinodynamic/accelerationBound",aMax)
+ps.setParameter("DynamicPlanner/sizeFootX",0.2)
+ps.setParameter("DynamicPlanner/sizeFootY",0.12)
+ps.setParameter("DynamicPlanner/friction",mu)
+ps.setParameter("Kinodynamic/forceYawOrientation",True)
+# sample only configuration with null velocity and acceleration :
+ps.setParameter("ConfigurationShooter/sampleExtraDOF",False)
+ps.setParameter("PathOptimization/RandomShortcut/NumberOfLoops",100)
+# initialize the viewer :
+from hpp.gepetto import ViewerFactory
+vf = ViewerFactory (ps)
+
+# load the module to analyse the environnement and compute the possible contact surfaces
+from hpp.corbaserver.affordance.affordance import AffordanceTool
+afftool = AffordanceTool ()
+afftool.setAffordanceConfig('Support', [0.5, 0.03, 5.])
+afftool.loadObstacleModel ("hpp_environments", "multicontact/maze_easy", "planning", vf)
+#load the viewer
+v = vf.createViewer(displayArrows = True)
+v.addLandmark(v.sceneName,1)
+afftool.visualiseAffordances('Support', v, v.color.lightBrown)
+
+q_init = rbprmBuilder.getCurrentConfig ();
+q_init[0:3] = [0.1,3,0.98]
+q_init[3:7] = [0,0,0,1]
+q_init[-6:-3] = [0.05,0,0]
+v(q_init)
+# sample random position on a circle of radius 2m
+q_goal = q_init[::]
+q_goal[0:2] = [17.8,15]
+ps.setInitialConfig (q_init)
+ps.addGoalConfig (q_goal)
+
+
+
+# Choosing RBPRM shooter and path validation methods.
+ps.selectConfigurationShooter("RbprmShooter")
+ps.selectPathValidation("RbprmPathValidation",0.05)
+ps.addPathOptimizer ("RandomShortcutDynamic")
+# Choosing kinodynamic methods :
+ps.selectSteeringMethod("RBPRMKinodynamic")
+ps.selectDistance("Kinodynamic")
+ps.selectPathPlanner("DynamicPlanner")
+
+t = ps.solve ()
+print "Guide planning time : ",t
+#v.solveAndDisplay("rm",10,0.01)
+for i in range(10):
+    print "Optimize path, "+str(i+1)+"/10 ... "
+    ps.optimizePath(ps.numberPaths()-1)
+pathId = ps.numberPaths()-1
+
+
+# display solution : 
+from hpp.gepetto import PathPlayer
+pp = PathPlayer (v)
+pp.dt=0.01
+pp.displayPath(pathId)
+v.client.gui.setVisibility("path_"+str(pathId)+"_root","ALWAYS_ON_TOP")
+pp.dt=0.01
+#pp(pathId)
+
+# move the robot out of the view before computing the contacts
+q_far = q_init[::]
+q_far[2] = -2
+v(q_far)
+

--- a/script/scenarios/sandbox/talos_maze_path.py
+++ b/script/scenarios/sandbox/talos_maze_path.py
@@ -15,7 +15,7 @@ mu=0.5# coefficient of friction
 # Creating an instance of the helper class, and loading the robot
 rbprmBuilder = Robot ()
 # Define bounds for the root : bounding box of the scenario
-rbprmBuilder.setJointBounds ("root_joint", [0,18.5, 0, 24., 0.98, 0.98])
+rbprmBuilder.setJointBounds ("root_joint", [0,18.5, 0, 24., rbprmBuilder.ref_height, rbprmBuilder.ref_height])
 rbprmBuilder.setJointBounds ('torso_1_joint', [0,0])
 rbprmBuilder.setJointBounds ('torso_2_joint', [0,0])
 
@@ -60,7 +60,7 @@ v.addLandmark(v.sceneName,1)
 afftool.visualiseAffordances('Support', v, v.color.lightBrown)
 
 q_init = rbprmBuilder.getCurrentConfig ();
-q_init[0:3] = [0.1,3,0.98]
+q_init[0:3] = [0.1,3,rbprmBuilder.ref_height]
 q_init[3:7] = [0,0,0,1]
 q_init[-6:-3] = [0.05,0,0]
 v(q_init)

--- a/script/scenarios/sandbox/talos_maze_path.py
+++ b/script/scenarios/sandbox/talos_maze_path.py
@@ -8,7 +8,7 @@ import time
 Robot.urdfName += "_large"
 
 vMax = 0.5# linear velocity bound for the root
-aMax = 0.5# linear acceleration bound for the root
+aMax = 0.7# linear acceleration bound for the root
 extraDof = 6
 mu=0.5# coefficient of friction
 # Creating an instance of the helper class, and loading the robot
@@ -44,7 +44,7 @@ ps.setParameter("DynamicPlanner/friction",mu)
 ps.setParameter("Kinodynamic/forceYawOrientation",True)
 # sample only configuration with null velocity and acceleration :
 ps.setParameter("ConfigurationShooter/sampleExtraDOF",False)
-ps.setParameter("PathOptimization/RandomShortcut/NumberOfLoops",100)
+ps.setParameter("PathOptimization/RandomShortcut/NumberOfLoops",500)
 # initialize the viewer :
 from hpp.gepetto import ViewerFactory
 vf = ViewerFactory (ps)
@@ -53,7 +53,7 @@ vf = ViewerFactory (ps)
 from hpp.corbaserver.affordance.affordance import AffordanceTool
 afftool = AffordanceTool ()
 afftool.setAffordanceConfig('Support', [0.5, 0.03, 5.])
-afftool.loadObstacleModel ("hpp_environments", "multicontact/maze_easy", "planning", vf)
+afftool.loadObstacleModel ("hpp_environments", "multicontact/maze_hard", "planning", vf)
 #load the viewer
 v = vf.createViewer(displayArrows = True)
 v.addLandmark(v.sceneName,1)
@@ -62,7 +62,7 @@ afftool.visualiseAffordances('Support', v, v.color.lightBrown)
 q_init = rbprmBuilder.getCurrentConfig ();
 q_init[0:3] = [0.1,3,rbprmBuilder.ref_height]
 q_init[3:7] = [0,0,0,1]
-q_init[-6:-3] = [0.05,0,0]
+q_init[-6:-3] = [0.01,0,0]
 v(q_init)
 # sample random position on a circle of radius 2m
 q_goal = q_init[::]
@@ -84,8 +84,9 @@ ps.selectPathPlanner("DynamicPlanner")
 t = ps.solve ()
 print "Guide planning time : ",t
 #v.solveAndDisplay("rm",10,0.01)
-for i in range(10):
-    print "Optimize path, "+str(i+1)+"/10 ... "
+
+for i in range(20):
+    print "Optimize path, "+str(i+1)+"/20 ... "
     ps.optimizePath(ps.numberPaths()-1)
 pathId = ps.numberPaths()-1
 
@@ -98,6 +99,8 @@ pp.displayPath(pathId)
 v.client.gui.setVisibility("path_"+str(pathId)+"_root","ALWAYS_ON_TOP")
 pp.dt=0.01
 #pp(pathId)
+
+v.client.gui.writeNodeFile("path_"+str(pathId)+"_root","guide_path_maze_hard.obj")
 
 # move the robot out of the view before computing the contacts
 q_far = q_init[::]

--- a/script/tools/display_tools.py
+++ b/script/tools/display_tools.py
@@ -8,7 +8,12 @@ def createSphere(name,r,size=0.01,color=[0,0,0,1]):
   r.client.gui.refresh()
 
 def moveSphere(name,r,pos):
-  q=pos+[1,0,0,0]
+  if len(pos) == 3:
+    q=pos+[1,0,0,0]
+  elif len(pos) == 7:
+    q = pos
+  else:
+    raise ValueError("pos should be of size 3 or 7 ")
   r.client.gui.applyConfiguration(name,q)
   r.client.gui.refresh()
 

--- a/script/tools/getSurfaceExtremumPoints.py
+++ b/script/tools/getSurfaceExtremumPoints.py
@@ -1,0 +1,92 @@
+import numpy as np
+from numpy import arange, array, append, cross, dot, zeros
+from numpy.linalg import norm
+
+from scipy.spatial import ConvexHull
+
+def normal(points):
+    p1 = array(points[0])
+    p2 = array(points[1])
+    p3 = array(points[2])
+    normal = cross((p2 - p1),(p3 - p1))
+    normal /= norm(normal)
+    return normal.tolist()
+
+def cutList2D(l):
+    return [el[:2] for el in l]
+    
+#precision handling     
+def roundPoints (points, precision):  
+    return [[round(x,precision) for x in p] for p in points]    
+    
+def removeDuplicates (points):
+    pList = []
+    for p in points:
+        if p not in pList:
+            pList.append(p)
+    return pList
+    
+def computeAxisAngleRotation(u, c):
+    ux = u[0] ; uy = u[1] ; uz = u[2]
+    s = np.sqrt(1- c*c)
+    return [[c+ux*ux*(1-c), ux*uy*(1-c)-uz*s, ux*uz*(1-c)+uy*s],
+    [uy*ux*(1-c)+uz*s,    c+uy*uy*(1-c), uy*uz*(1-c)-ux*s],
+    [uz*ux*(1-c)-uy*s, uz*uy*(1-c)+ux*s,    c+uz*uz*(1-c)]]
+
+def getSurfaceRotation (surface):
+    n = surface[1]
+    cosx = np.dot(surface[1],[0,0,1])
+    #print "normal = ",n
+    axisx = np.cross(surface[1],[0,0,1])
+    #print "axisx = ",axisx
+    n_axisx = norm(axisx)
+    #print "axisx norm = ",n_axisx
+    if n_axisx > 0:
+      axisx /= n_axisx
+    return computeAxisAngleRotation(axisx, cosx)
+    
+def getPtsRotation (points):
+    return getSurfaceRotation((points,normal(points)))
+
+def getSurfaceTranslation (surface):
+    return [sum(x)/len(x) for x in zip(*surface[0])]     
+    
+def getPtsTranslation (points):
+    return getSurfaceTranslation((points,normal(points)))
+
+#into xy plane, back to its position    
+def allignSurface (surface):        
+    R = getSurfaceRotation(surface)
+    t = getSurfaceTranslation(surface)
+    translatedPts = [(array(p)-array(t)).tolist() for p in surface[0]]
+    rotatedPts = [np.dot(R,p).tolist() for p in translatedPts]
+    return [(array(p)+array(t)).tolist() for p in rotatedPts]  
+
+def allignPoints (points):
+    return allignSurface((points, normal(points)))
+    
+def pointsTransform (points,R,t):
+    translatedPts = [(array(pt)-array(t)).tolist() for pt in points]
+    rotatedPts = [np.dot(R,pt).tolist() for pt in translatedPts]
+    return [(array(pt)+array(t)).tolist() for pt in rotatedPts]  
+    
+def getSurfaceExtremumPoints(el):
+    pts = removeDuplicates(el[0]+el[1])
+    apts = allignPoints(pts)
+    #print pts
+    hull = ConvexHull(cutList2D(apts))#,False,'QbB')
+    return [pts[idx] for idx in hull.vertices]
+    
+        
+#get contact surfaces (pts and normal)
+def contactSurfaces(afftool):
+    l = afftool.getAffordancePoints("Support")
+    return [(getSurfaceExtremumPoints(el)) for el in l]
+    #return [(getSurfaceExtremumPoints(el), normal(el[0])) for el in l]
+    
+    
+######################################################################### 
+
+
+#get surface information
+#surfaces = contactSurfaces(afftool) 

--- a/script/tools/surfacesToGazebo.py
+++ b/script/tools/surfacesToGazebo.py
@@ -1,0 +1,135 @@
+import tools.getSurfaceExtremumPoints as ep
+import numpy as np
+from pinocchio import Quaternion
+from pinocchio.utils import matrixToRpy
+
+NAME_ID = 0
+NAME = "box"
+WIDTH = 0.02
+Z_AXIS = np.matrix([0,0,1]).T
+
+"""
+<model name="box_1_model">
+      <pose>0.15 0.25 0.145 0 0 0</pose>
+      <static>true</static>
+      <link name="box_1_body">
+        <inertial>
+          <mass>1.0</mass>
+          <inertia>
+            <ixx>1.0</ixx>
+            <ixy>0.0</ixy>
+            <ixz>0.0</ixz>
+            <iyy>1.0</iyy>
+            <iyz>0.0</iyz>
+            <izz>1.0</izz>
+          </inertia>
+        </inertial>
+        <collision name="collision">
+          <geometry>
+            <box>
+              <size>0.3 0.5 0.03</size>
+            </box>
+          </geometry>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>0.3 0.5 0.03</size>
+            </box>
+          </geometry>
+        </visual>
+      </link>
+</model>
+"""
+
+
+def computePoseFromSurface(surface):
+  points = surface
+  #normal = surface[1]
+  normal = [0,0,1]
+  center = np.zeros(3)
+  for pt in points:
+    center += np.array(pt)
+  center /= len(points)
+  center -= np.array(normal)*(WIDTH/2.)
+
+  # rotation in rpy : 
+  q_rot = Quaternion()
+  n_m = np.matrix(normal).T
+  q_rot.setFromTwoVectors(Z_AXIS,n_m)
+  rpy = matrixToRpy(q_rot.matrix())
+  pose = center.tolist() + rpy.T.tolist()[0]
+  return pose
+
+
+# ASSUME RECTANGLE ALIGNED WITH X,Y AXIS !!
+# FIXME
+def computeSizeFromSurface(surface):
+  size = [0,0,0]
+  size[2] = WIDTH
+  points = surface
+  for i in range(len(points)-1):
+    pt0 = points[i]
+    pt1 = points[i+1]
+    #print "pt0 = ",pt0
+    #print "pt1 = ",pt1
+    sX = (abs(pt0[0] - pt1[0]))
+    if sX > 0.01:
+      size[0] = sX
+    sY = (abs(pt0[1] - pt1[1]))
+    if sY > 0.01:
+      size[1] = sY
+
+  return size
+
+def genStringForSurface(surface):
+  pose = computePoseFromSurface(surface)
+  size = computeSizeFromSurface(surface)
+  global NAME_ID
+  res = ""
+  res += "<model name=\""+NAME+"_"+str(NAME_ID)+"_model\">\n"
+  res += "\t<pose>"+str(pose[0])+" "+str(pose[1])+" "+str(pose[2])+" "+str(pose[3])+" "+str(pose[4])+" "+str(pose[5])+"</pose>\n"
+  res += "\t<static>true</static>\n"
+  res += "\t<link name=\""+NAME+"_"+str(NAME_ID)+"_body\">\n"
+  res += "\t<inertial>\n"
+  res += "\t\t<mass>1.0</mass>\n"
+  res += "\t\t<inertia>\n"
+  res += "\t\t\t<ixx>1.0</ixx>\n"
+  res += "\t\t\t<ixy>0.0</ixy>\n"
+  res += "\t\t\t<ixz>0.0</ixz>\n"
+  res += "\t\t\t<iyy>1.0</iyy>\n"
+  res += "\t\t\t<iyz>0.0</iyz>\n"
+  res += "\t\t\t<izz>1.0</izz>\n"
+  res += "\t\t</inertia>\n"
+  res += "\t</inertial>\n"
+  res += "\t\t<collision name=\"collision\">\n"
+  res += "\t\t<geometry>\n"
+  res += "\t\t\t<box>\n"
+  res += "\t\t\t\t<size>"+str(size[0])+" "+str(size[1])+" "+str(size[2])+"</size>\n"
+  res += "\t\t\t</box>\n"
+  res += "\t\t</geometry>\n"
+  res += "\t</collision>\n"
+  res += "\t<visual name=\"visual\">\n"
+  res += "\t\t<geometry>\n"
+  res += "\t\t\t<box>\n"
+  res += "\t\t\t\t<size>"+str(size[0])+" "+str(size[1])+" "+str(size[2])+"</size>\n"
+  res += "\t\t\t</box>\n"
+  res += "\t\t</geometry>\n"
+  res += "\t</visual>\n"
+  res += "\t</link>\n"
+  res += "</model>\n"
+  NAME_ID += 1
+  return res
+
+
+def getGazeboString(afftool):
+  surfaces = ep.contactSurfaces(afftool)
+  res = ""
+  for surface in surfaces:
+    res += genStringForSurface(surface)
+    res += "\n\n"
+
+  return res
+
+
+

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -85,6 +85,7 @@ INSTALL(
         ${CMAKE_CURRENT_SOURCE_DIR}/hpp/corbaserver/rbprm/rbprmfullbody.py
         ${CMAKE_CURRENT_SOURCE_DIR}/hpp/corbaserver/rbprm/rbprmstate.py
         ${CMAKE_CURRENT_SOURCE_DIR}/hpp/corbaserver/rbprm/state_alg.py
+        ${CMAKE_CURRENT_SOURCE_DIR}/hpp/corbaserver/rbprm/fewstepsplanner.py
   DESTINATION ${PYTHON_SITELIB}/hpp/corbaserver/rbprm
   )
 INSTALL(

--- a/src/hpp/corbaserver/rbprm/fewstepsplanner.py
+++ b/src/hpp/corbaserver/rbprm/fewstepsplanner.py
@@ -100,7 +100,7 @@ class FewStepPlanner(object):
   def interpolateStates(self, stepsize, pathId = 1, robustnessTreshold = 0, filterStates = False, testReachability = True, quasiStatic = False, erasePreviousStates = True):
     return _interpolateState(self.problemSolver, self.fullBody, stepsize, pathId, robustnessTreshold, filterStates, testReachability, quasiStatic, erasePreviousStates)
     
-  def goToQuasiStatic(self, currentState, toPos, stepsize = 0.002, goalLimbsInContact = None, goalNormals = None, displayGuidePath = False):
+  def goToQuasiStatic(self, currentState, toPos, stepsize = 0.002, goalLimbsInContact = None, goalNormals = None, displayGuidePath = False, erasePreviousStates = False):
     pId = self.guidePath(currentState.q()[:7], toPos, displayPath = displayGuidePath)    
     self.fullBody.setStartStateId(currentState.sId)
     targetState = currentState.q()[:]; targetState[:7] = toPos
@@ -109,7 +109,7 @@ class FewStepPlanner(object):
     if goalNormals is None:
       goalNormals = [[0.,0.,1.] for _ in range(len(goalLimbsInContact))]
     self.fullBody.setEndState(targetState, goalLimbsInContact,goalNormals)
-    return self.interpolateStates(stepsize,pathId=pId,robustnessTreshold = 1, filterStates = True,quasiStatic=True, erasePreviousStates = False)
+    return self.interpolateStates(stepsize,pathId=pId,robustnessTreshold = 1, filterStates = True,quasiStatic=True, erasePreviousStates = erasePreviousStates)
     
        
               

--- a/src/hpp/corbaserver/rbprm/rbprmbuilder.py
+++ b/src/hpp/corbaserver/rbprm/rbprmbuilder.py
@@ -18,7 +18,6 @@
 
 from hpp.corbaserver.rbprm import Client as RbprmClient
 from hpp.corbaserver.robot import Robot
-import hpp.gepetto.blender.exportmotion as em
 
 ## Load and handle a RbprmDevice robot for rbprm planning
 #
@@ -94,6 +93,7 @@ class Builder (Robot):
   # \param pathId if of the considered path
   # \param filename name of the output file where to save the output
   def exportPath (self, viewer, problem, pathId, stepsize, filename):
+    import hpp.gepetto.blender.exportmotion as em
     em.exportPath(viewer, self.client.robot, problem, pathId, stepsize, filename)
 
   ## set a reference position of the end effector for the given ROM

--- a/src/hpp/corbaserver/rbprm/rbprmstate.py
+++ b/src/hpp/corbaserver/rbprm/rbprmstate.py
@@ -179,11 +179,12 @@ class StateHelper(object):
     # \param n 3d normal of the contact location center
     # \param max_num_sample number of times it will try to randomly sample a configuration before failing
     # \param lockOtherJoints : if True, the values of all the joints exepct the ones of 'limbName' are constrained to be constant.
+    # \param rotation : desired rotation of the end-effector in contact, expressed as Quaternion (x,y,z,w). If different from zero, the normal is ignored. Otherwise the rotation is automatically computed from the normal (with one axis of freedom)
     #                This only affect the first projection, if max_num_sample > 0 and the first projection was unsuccessfull, the parameter is ignored
     # \return (State, success) whether the creation was successful, as well as the new state
     @staticmethod
-    def addNewContact(state, limbName, p, n, num_max_sample = 0, lockOtherJoints= False):
-        sId = state.cl.addNewContact(state.sId, limbName, p, n, num_max_sample,lockOtherJoints)
+    def addNewContact(state, limbName, p, n, num_max_sample = 0, lockOtherJoints= False,rotation = [0,0,0,0]):
+        sId = state.cl.addNewContact(state.sId, limbName, p, n, num_max_sample,lockOtherJoints,rotation)
         if(sId != -1):
             return State(state.fullBody, sId = sId), True
         return state, False

--- a/src/hpp/corbaserver/rbprm/state_alg.py
+++ b/src/hpp/corbaserver/rbprm/state_alg.py
@@ -23,7 +23,7 @@ try:
     from CWC_methods import compute_CWC, is_stable
     from lp_find_point import find_valid_c_cwc, find_valid_c_cwc_qp, lp_ineq_4D
 except:
-    print "WARNING: in state_alg, some optinal dependencies were not found"
+    #~ print "WARNING: in state_alg, some optinal dependencies were not found"
     pass
 
 ## algorithmic methods on state
@@ -81,8 +81,8 @@ def computeIntermediateState(sfrom, sto):
 # \param p 3d position of the point
 # \param n 3d normal of the contact location center
 # \return (State, success) whether the creation was successful, as well as the new state
-def addNewContact(state, limbName, p, n, num_max_sample = 0):
-    sId = state.cl.addNewContact(state.sId, limbName, p, n, num_max_sample)
+def addNewContact(state, limbName, p, n, num_max_sample = 0, lockOtherJoints = False):
+    sId = state.cl.addNewContact(state.sId, limbName, p, n, num_max_sample, lockOtherJoints)
     if(sId != -1):
         return State(state.fullBody, sId = sId), True
     return state, False

--- a/src/rbprmbuilder.impl.cc
+++ b/src/rbprmbuilder.impl.cc
@@ -1579,8 +1579,7 @@ namespace hpp {
                       hppDout(warning,"For rom : "<<it->first<<" unable to cast in a AllCollisionsValidationReport, did you correctly call computeAllContacts(true) before generating the report ? ");
                       //return;
                         }
-                  if(romReports->collisionReports.size()> 1){
-
+                  if(romReports->collisionReports.size()> 0){
                       for(std::vector<CollisionValidationReportPtr_t>::const_iterator itAff = romReports->collisionReports.begin() ; itAff != romReports->collisionReports.end() ; ++itAff){
                          res.push_back((*itAff)->object2->name ());
                       }

--- a/src/rbprmbuilder.impl.hh
+++ b/src/rbprmbuilder.impl.hh
@@ -363,7 +363,7 @@ namespace hpp {
 
         virtual Names_t* getAllLimbsNames()throw (hpp::Error);
         virtual CORBA::Short addNewContact(unsigned short stateId, const char* limbName,
-                                            const hpp::floatSeq& position, const hpp::floatSeq& normal, unsigned short max_num_sample, bool lockOtherJoints) throw (hpp::Error);
+                                            const hpp::floatSeq& position, const hpp::floatSeq& normal, unsigned short max_num_sample, bool lockOtherJoints, const floatSeq &rotation) throw (hpp::Error);
         virtual CORBA::Short removeContact(unsigned short stateId, const char* limbName) throw (hpp::Error);
         virtual hpp::floatSeq* computeTargetTransform(const char* limbName, const hpp::floatSeq& configuration, const hpp::floatSeq& p, const hpp::floatSeq& n) throw (hpp::Error);
         virtual Names_t* getEffectorsTrajectoriesNames(unsigned short pathId)throw (hpp::Error);


### PR DESCRIPTION
### API change:

state.addNewContact now take an optionnal argument to constraint the contact rotation. If this argument is specified, the `normal` argument is ignored and the new contact created will be forced to have the specified rotation. 

### New/updated scenario scripts : 

* anymal on flat floor
* anymal on 'modular_palet' environment
* talos on inclined platform : use scaled up feet collision shape to be more robust
* talos on maze environment (only _path script)

### New/updated tools scripts : 

* display_tools : moveSphere can now take a vector 7 (pos + quaternion) as input to apply the correct rotation
* getSurfaceExtremumPoints : new script  to manipulate affordance objects and convert them to points list
* surfacesToGazebo : new script to convert affordances surfaces to gazebo .world (really not generic for the moment, only work for rectangles with a normal along z)

### Minor changes / fix : 
* getCollisionSurfaces : fix error preventing this method to return a surface when only one surface was in collision
* rbprmbuilder.py : only try to import gepetto viewer blender script when needed.