### PR TITLE
Re-initialize startState_ and endState_

### DIFF
--- a/src/rbprmbuilder.impl.cc
+++ b/src/rbprmbuilder.impl.cc
@@ -1191,6 +1191,7 @@ void RbprmBuilder::setStartState(const hpp::floatSeq& configuration,
     bool validity = problemSolver()->problem()->configValidations()->validate(
         dofArrayToConfig(fullBody()->device_, configuration), validationReport);
     if (validity) {
+      startState_ = State();
       SetPositionAndNormal(startState_, fullBody(), configuration, names);
     } else {
       std::ostringstream oss;
@@ -1235,6 +1236,7 @@ void RbprmBuilder::setEndState(const hpp::floatSeq& configuration,
     bool validity = problemSolver()->problem()->configValidations()->validate(
         dofArrayToConfig(fullBody()->device_, configuration), validationReport);
     if (validity) {
+      endState_ = State();
       SetPositionAndNormal(endState_, fullBody(), configuration, names);
     } else {
       std::ostringstream oss;


### PR DESCRIPTION
When calling Interpolate several times, states were stacking in these variables and increasing the computation time.