### PR TITLE
using full path to killall

### DIFF
--- a/src/hpp/corbaserver/rbprm/utils.py
+++ b/src/hpp/corbaserver/rbprm/utils.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2020, CNRS
 # Authors: Guilhem Saurel <guilhem.saurel@laas.fr>
 
+import os
 import subprocess
 import time
 
@@ -12,7 +13,16 @@ class ServerManager:
         subprocess.run(['/usr/bin/killall', self.server])
 
     def __enter__(self):
-        self.process = subprocess.Popen(self.server)
+        """Run the server in background
+
+        stdout and stderr outputs of the child process are redirected to devnull (hidden).
+        preexec_fn is used to ignore ctrl-c signal send to the main script
+        (otherwise they are forwarded to the child process)
+        """
+        self.process = subprocess.Popen(self.server,
+                                        stdout=subprocess.DEVNULL,
+                                        stderr=subprocess.DEVNULL,
+                                        preexec_fn=os.setpgrp)
         # give it some time to start
         time.sleep(3)
 

--- a/src/hpp/corbaserver/rbprm/utils.py
+++ b/src/hpp/corbaserver/rbprm/utils.py
@@ -9,7 +9,7 @@ class ServerManager:
     """A context to ensure a server is running."""
     def __init__(self, server):
         self.server = server
-        subprocess.run(['killall', self.server])
+        subprocess.run(['/usr/bin/killall', self.server])
 
     def __enter__(self):
         self.process = subprocess.Popen(self.server)


### PR DESCRIPTION
Hi,

While testing the 4.9.0 Release, I got this issue:
```
FileNotFoundError: [Errno 2] No such file or directory: 'killall': 'killall'
```

So I guess we need the full path.

While here, I  noticed a similar code in `__main__.py`, so to de-duplicate some code, I used the `ServerManager` there too. We could  also use it for `gepetto-gui`, but this can wait.


@pFernbach : Could you check that these changes work for you ?