### PR TITLE
Update API to load robots

### DIFF
--- a/idl/hpp/corbaserver/rbprm/rbprmbuilder.idl
+++ b/idl/hpp/corbaserver/rbprm/rbprmbuilder.idl
@@ -32,21 +32,14 @@ module hpp
     /// This function can be called several times to include several ROMs (one for each limb)
     /// The device automatically has an anchor joint called "base_joint" as
     /// root joint.
-    /// \param romRobotName the name of the robot range of motion.
-    ///  Load robot model
+    /// \param robotName the name of the robot range of motion,
     /// \param rootJointType type of root joint among "anchor", "freeflyer",
     /// "planar",
-    /// \param packageName Name of the ROS package containing the model,
-    /// \param modelName Name of the package containing the model
-    /// \param urdfSuffix suffix for urdf file,
+    /// \param urdfName name of the urdf file. It may contain
+    ///        "file://", or "package://" prefixes.
     ///
-    /// The ros url are built as follows:
-    /// "package://${packageName}/urdf/${modelName}${urdfSuffix}.urdf"
-    /// "package://${packageName}/srdf/${modelName}${srdfSuffix}.srdf"
-    ///
-    void loadRobotRomModel (in string romRobotName, in string rootJointType,
-             in string packageName, in string modelName,
-             in string urdfSuffix, in string srdfSuffix)
+    void loadRobotRomModel (in string robotName, in string rootJointType,
+    in string urdfName)
       raises (Error);
 
 
@@ -54,20 +47,16 @@ module hpp
 
     /// The device automatically has an anchor joint called "base_joint" as
     /// root joint.
-    /// \param trunkRobotName the name of the robot trunk used for collision.
+    /// \param robotName the name of the robot trunk used for collision,
     /// \param rootJointType type of root joint among "anchor", "freeflyer",
     /// "planar",
-    /// \param packageName Name of the ROS package containing the model,
-    /// \param modelName Name of the package containing the model
-    /// \param urdfSuffix suffix for urdf file,
+    /// \param urdfName name of the urdf file. It may contain
+    ///        "file://", or "package://" prefixes.
+    /// \param srdfName name of the srdf file. It may contain
+    ///        "file://", or "package://" prefixes.
     ///
-    /// The ros url are built as follows:
-    /// "package://${packageName}/urdf/${modelName}${urdfSuffix}.urdf"
-    /// "package://${packageName}/srdf/${modelName}${srdfSuffix}.srdf"
-    ///
-    void loadRobotCompleteModel (in string trunkRobotName, in string rootJointType,
-             in string packageName, in string modelName,
-             in string urdfSuffix, in string srdfSuffix)
+    void loadRobotCompleteModel (in string robotName, in string rootJointType,
+    in string urdfName, in string srdfName)
       raises (Error);
 
     ///  Load fullbody robot model

--- a/idl/hpp/corbaserver/rbprm/rbprmbuilder.idl
+++ b/idl/hpp/corbaserver/rbprm/rbprmbuilder.idl
@@ -70,23 +70,22 @@ module hpp
              in string urdfSuffix, in string srdfSuffix)
       raises (Error);
 
+    ///  Load fullbody robot model
+    ///
     /// Create a RbprmFullBody object
     /// The device automatically has an anchor joint called "base_joint" as
     /// root joint.
-    /// \param trunkRobotName the name of the robot trunk used for collision.
+    ///
+    /// \param robotName Name of the robot that is constructed,
     /// \param rootJointType type of root joint among "anchor", "freeflyer",
     /// "planar",
-    /// \param packageName Name of the ROS package containing the model,
-    /// \param modelName Name of the package containing the model
-    /// \param urdfSuffix suffix for urdf file,
+    /// \param urdfName name of the urdf file. It may contain
+    ///        "file://", or "package://" prefixes.
+    /// \param srdfName name of the srdf file. It may contain
+    ///        "file://", or "package://" prefixes.
     ///
-    /// The ros url are built as follows:
-    /// "package://${packageName}/urdf/${modelName}${urdfSuffix}.urdf"
-    /// "package://${packageName}/srdf/${modelName}${srdfSuffix}.srdf"
-    ///
-    void loadFullBodyRobot (in string trunkRobotName, in string rootJointType,
-             in string packageName, in string modelName,
-             in string urdfSuffix, in string srdfSuffix, in string selectedProblem)
+    void loadFullBodyRobot (in string robotName, in string rootJointType,
+       in string urdfName, in string srdfName, in string selectedProblem)
       raises (Error);
 
 		/// Create a RbprmFullBody object

--- a/matlab/effectorRomToObj.m
+++ b/matlab/effectorRomToObj.m
@@ -1,0 +1,9 @@
+% Open it on blender with default axis setting and export it with x forward. 
+% Use decimate to reduce the number of faces, don't forget to triangulate faces before exporting
+
+function [] = effectorRomToObj(filename, outname)
+delimiterIn = ',';
+headerlinesIn = 0;
+points = importdata(filename,delimiterIn,headerlinesIn);
+k = convhull(points);
+vertface2obj(points,k,outname)

--- a/matlab/vertface2obj.m
+++ b/matlab/vertface2obj.m
@@ -1,0 +1,21 @@
+function vertface2obj(v,f,name)
+% VERTFACE2OBJ Save a set of vertice coordinates and faces as a Wavefront/Alias Obj file
+% VERTFACE2OBJ(v,f,fname)
+%     v is a Nx3 matrix of vertex coordinates.
+%     f is a Mx3 matrix of vertex indices. 
+%     fname is the filename to save the obj file.
+
+fid = fopen(name,'w');
+
+for i=1:size(v,1)
+fprintf(fid,'v %f %f %f\n',v(i,1),v(i,2),v(i,3));
+end
+
+fprintf(fid,'g foo\n');
+
+for i=1:size(f,1);
+fprintf(fid,'f %d %d %d\n',f(i,1),f(i,2),f(i,3));
+end
+fprintf(fid,'g\n');
+
+fclose(fid);

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -88,6 +88,7 @@ SET(${PROJECT_NAME}_PYTHON_FILES
 SET(${PROJECT_NAME}_PYTHON_TOOLS
     affordance_centroids.py
     com_constraints.py
+    constants_and_tools.py
     constraint_to_dae.py
     cwc_trajectory_helper.py
     cwc_trajectory.py

--- a/src/hpp/corbaserver/rbprm/rbprmfullbody.py
+++ b/src/hpp/corbaserver/rbprm/rbprmfullbody.py
@@ -28,7 +28,8 @@ from numpy import array, matrix
 #  trunk of the robot, one for the range of motion
 class FullBody(Robot):
     # # Constructor
-    def __init__(self, load=True, clientRbprm=None):
+    def __init__(self, robotName = None, rootJointType = None, load = True, client = None, hppcorbaClient = None, clientRbprm=None):
+        Robot.__init__(self, robotName, rootJointType, False, client, hppcorbaClient)
         self.tf_root = "base_link"
         if clientRbprm == None:
             self.clientRbprm = RbprmClient()
@@ -36,27 +37,22 @@ class FullBody(Robot):
             self.clientRbprm = clientRbprm
         self.load = load
         self.limbNames = []
+        if load:
+          self.loadFullBodyModel(robotName, rootJointType)
 
     # # Virtual function to load the fullBody robot model.
-    #
-    # \param urdfName urdf description of the fullBody robot
+    # This method looks for the following class attribute in order to find the files to load:
+    # First it looks for urdfFilename and srdfFilename and use it if available
+    # Otherwise it looks for packageName, urdfName, urdfSuffix, srdfSuffix
+    # \param robotNamethe name of the robot
     # \param rootJointType type of root joint among ("freeflyer", "planar",
     #          "anchor"), WARNING. Currently RB-PRM only considerds freeflyer roots
-    # \param meshPackageName name of the meshpackage from where the robot mesh will be loaded
-    # \param packageName name of the package from where the robot will be loaded
-    # \param urdfSuffix optional suffix for the urdf of the robot package
-    # \param srdfSuffix optional suffix for the srdf of the robot package
-    def loadFullBodyModel(self, urdfName, rootJointType, meshPackageName, packageName, urdfSuffix, srdfSuffix, client=None):
-        Robot.__init__(self, urdfName, rootJointType, False, client)
-        self.clientRbprm.rbprm.loadFullBodyRobot(urdfName, rootJointType, packageName, urdfName, urdfSuffix,
-                                                 srdfSuffix,
+    def loadFullBodyModel(self, robotName, rootJointType):
+        urdfFilename, srdfFilename = self.urdfSrdfFilenames () # inherited method from corbaserver.robot
+        print("selected problem: ",self.client.problem.getSelected("problem")[0])
+        self.clientRbprm.rbprm.loadFullBodyRobot(robotName, rootJointType,
+                                                 urdfFilename, srdfFilename,
                                                  self.client.problem.getSelected("problem")[0])
-        self.client.robot.meshPackageName = meshPackageName
-        self.meshPackageName = meshPackageName
-        self.packageName = packageName
-        self.urdfName = urdfName
-        self.urdfSuffix = urdfSuffix
-        self.srdfSuffix = srdfSuffix
         self.octrees = {}
 
     # Virtual function to load the fullBody robot model.

--- a/src/hpp/corbaserver/rbprm/scenarios/abstract_path_planner.py
+++ b/src/hpp/corbaserver/rbprm/scenarios/abstract_path_planner.py
@@ -156,7 +156,7 @@ class AbstractPathPlanner:
             else:
                 self.ps.addPathOptimizer("RandomShortcut")
 
-    def solve(self):
+    def solve(self, display_roadmap = False):
         """
         Solve the path planning problem.
         q_init and q_goal must have been defined before calling this method
@@ -168,7 +168,10 @@ class AbstractPathPlanner:
         self.ps.setInitialConfig(self.q_init)
         self.ps.addGoalConfig(self.q_goal)
         self.v(self.q_init)
-        t = self.ps.solve()
+        if display_roadmap and self.v.client.gui.getNodeList() is not None:
+            t = self.v.solveAndDisplay("roadmap", 5, 0.001)
+        else:
+            t = self.ps.solve()
         print("Guide planning time : ", t)
 
 

--- a/src/hpp/corbaserver/rbprm/scenarios/abstract_path_planner.py
+++ b/src/hpp/corbaserver/rbprm/scenarios/abstract_path_planner.py
@@ -1,7 +1,9 @@
 from abc import abstractmethod
 from hpp.gepetto import ViewerFactory, PathPlayer
 from hpp.corbaserver.affordance.affordance import AffordanceTool
-from hpp.corbaserver import ProblemSolver
+from hpp.corbaserver import ProblemSolver, Client
+from hpp.corbaserver import createContext, loadServerPlugin
+from hpp.corbaserver.rbprm import Client as RbprmClient
 
 class AbstractPathPlanner:
 
@@ -13,7 +15,11 @@ class AbstractPathPlanner:
     extra_dof_bounds = None
     robot_node_name = None  # name of the robot in the node list of the viewer
 
-    def __init__(self):
+    def __init__(self, context = None):
+        """
+        Constructor
+        :param context: An optional string that give a name to a corba context instance
+        """
         self.v_max = -1  # bounds on the linear velocity for the root, negative values mean unused
         self.a_max = -1  # bounds on the linear acceleration for the root, negative values mean unused
         self.root_translation_bounds = [0] * 6  # bounds on the root translation position (-x, +x, -y, +y, -z, +z)
@@ -27,6 +33,17 @@ class AbstractPathPlanner:
         self.size_foot_y = 0  # size of the feet along the y axis
         self.q_init = []
         self.q_goal = []
+        self.context = context
+        if context:
+            createContext(context)
+            loadServerPlugin(context, 'rbprm-corba.so')
+            loadServerPlugin(context, 'affordance-corba.so')
+            self.hpp_client = Client(context=context)
+            self.hpp_client.problem.selectProblem(context)
+            self.rbprm_client = RbprmClient(context=context)
+        else:
+            self.hpp_client = None
+            self.rbprm_client = None
 
     @abstractmethod
     def load_rbprm(self):
@@ -107,7 +124,11 @@ class AbstractPathPlanner:
         :param visualize_affordances: list of affordances type to visualize, default to none
         """
         vf = ViewerFactory(self.ps)
-        self.afftool = AffordanceTool()
+        if self.context:
+            self.afftool = AffordanceTool(context=self.context)
+            self.afftool.client.affordance.affordance.resetAffordanceConfig()  # FIXME: this should be called in afftool constructor
+        else:
+            self.afftool = AffordanceTool()
         self.afftool.setAffordanceConfig('Support', [0.5, 0.03, 0.00005])
         self.afftool.loadObstacleModel("package://"+env_package + "/urdf/" + env_name + ".urdf",
                                        "planning", vf, reduceSizes=reduce_sizes)

--- a/src/hpp/corbaserver/rbprm/scenarios/anymal_contact_generator.py
+++ b/src/hpp/corbaserver/rbprm/scenarios/anymal_contact_generator.py
@@ -23,7 +23,7 @@ class AnymalContactGenerator(AbstractContactGenerator):
         self.fullbody.setEndState(self.q_goal, self.end_contacts, normals_end)
 
     def load_fullbody(self):
-        from hpp.corbaserver.rbprm.anymal import Robot
+        from anymal_rbprm.anymal import Robot
         self.fullbody = Robot()
         self.q_ref = self.fullbody.referenceConfig[::] + [0] * self.path_planner.extra_dof
         self.weight_postural = self.fullbody.postureWeights[::] + [0] * self.path_planner.extra_dof

--- a/src/hpp/corbaserver/rbprm/scenarios/anymal_path_planner.py
+++ b/src/hpp/corbaserver/rbprm/scenarios/anymal_path_planner.py
@@ -19,7 +19,7 @@ class AnymalPathPlanner(AbstractPathPlanner):
         self.robot_node_name = "anymal_trunk"
 
     def load_rbprm(self):
-        from hpp.corbaserver.rbprm.anymal_abstract import Robot
+        from anymal_rbprm.anymal_abstract import Robot
         self.rbprmBuilder = Robot(client=self.hpp_client, clientRbprm=self.rbprm_client)
 
     def set_joints_bounds(self):

--- a/src/hpp/corbaserver/rbprm/scenarios/anymal_path_planner.py
+++ b/src/hpp/corbaserver/rbprm/scenarios/anymal_path_planner.py
@@ -2,8 +2,8 @@ from .abstract_path_planner import AbstractPathPlanner
 
 
 class AnymalPathPlanner(AbstractPathPlanner):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, context = None):
+        super().__init__(context)
         # set default bounds to a large workspace on x,y with small interval around reference z value
         self.root_translation_bounds = [-5., 5., -5., 5., 0.4, 0.5]
         # set default used limbs to be both feet
@@ -20,7 +20,7 @@ class AnymalPathPlanner(AbstractPathPlanner):
 
     def load_rbprm(self):
         from hpp.corbaserver.rbprm.anymal_abstract import Robot
-        self.rbprmBuilder = Robot()
+        self.rbprmBuilder = Robot(client=self.hpp_client, clientRbprm=self.rbprm_client)
 
     def set_joints_bounds(self):
         super().set_joints_bounds()

--- a/src/hpp/corbaserver/rbprm/scenarios/demos/talos_flatGround_path.py
+++ b/src/hpp/corbaserver/rbprm/scenarios/demos/talos_flatGround_path.py
@@ -2,14 +2,28 @@ from hpp.corbaserver.rbprm.scenarios.talos_path_planner import TalosPathPlanner
 
 
 class PathPlanner(TalosPathPlanner):
+
+    def init_problem(self):
+        self.a_max = 0.05
+        super().init_problem()
+        # greatly increase the number of loops of the random shortcut
+        self.ps.setParameter("PathOptimization/RandomShortcut/NumberOfLoops", 50)
+        # force the base orientation to follow the direction of motion along the Z axis
+        self.ps.setParameter("Kinodynamic/forceYawOrientation", True)
+
+
     def run(self):
         self.init_problem()
 
         self.q_init[:2] = [0, 0]
-        self.q_goal[:2] = [1, 0]
+        self.q_goal[:2] = [1., 0]
+
+        # Constraint the initial orientation when forceYawOrientation = True, expressed as a 3D vector (x,y,z)
+        #self.q_init[-6:-3] = [0.1, 0, 0]
+        #self.q_goal[-6:-3] = [0, -0.1, 0]
 
         self.init_viewer("multicontact/ground", visualize_affordances=["Support"])
-        self.init_planner()
+        self.init_planner(True, False)
         self.solve()
         self.display_path()
         # self.play_path()

--- a/src/hpp/corbaserver/rbprm/scenarios/demos/talos_flatGround_path.py
+++ b/src/hpp/corbaserver/rbprm/scenarios/demos/talos_flatGround_path.py
@@ -4,7 +4,7 @@ from hpp.corbaserver.rbprm.scenarios.talos_path_planner import TalosPathPlanner
 class PathPlanner(TalosPathPlanner):
 
     def init_problem(self):
-        self.a_max = 0.05
+        self.a_max = 0.1
         super().init_problem()
         # greatly increase the number of loops of the random shortcut
         self.ps.setParameter("PathOptimization/RandomShortcut/NumberOfLoops", 50)

--- a/src/hpp/corbaserver/rbprm/scenarios/demos/talos_navBauzil_hard_path.py
+++ b/src/hpp/corbaserver/rbprm/scenarios/demos/talos_navBauzil_hard_path.py
@@ -6,7 +6,7 @@ class PathPlanner(TalosPathPlanner):
         from talos_rbprm.talos_abstract import Robot
         Robot.urdfName = "talos_trunk_large"  # load the model with conservative bounding boxes for trunk
         self.robot_node_name = "talos_trunk_large"
-        self.rbprmBuilder = Robot()
+        self.rbprmBuilder = Robot(client=self.hpp_client, clientRbprm=self.rbprm_client)
 
     def init_problem(self):
         super().init_problem()

--- a/src/hpp/corbaserver/rbprm/scenarios/demos/talos_plateformes.py
+++ b/src/hpp/corbaserver/rbprm/scenarios/demos/talos_plateformes.py
@@ -11,7 +11,7 @@ class ContactGenerator(TalosContactGenerator):
         # use a model with upscaled collision geometry for the feet
         Robot.urdfSuffix += "_safeFeet"
         self.fullbody = Robot()
-        self.q_ref = self.fullbody.referenceConfig[::] + [0] * self.path_planner.extra_dof
+        self.q_ref = self.fullbody.referenceConfig_legsApart[::] + [0] * self.path_planner.extra_dof
         self.weight_postural = self.fullbody.postureWeights[::] + [0] * self.path_planner.extra_dof
 
     def set_joints_bounds(self):

--- a/src/hpp/corbaserver/rbprm/scenarios/demos/talos_plateformes_path.py
+++ b/src/hpp/corbaserver/rbprm/scenarios/demos/talos_plateformes_path.py
@@ -12,8 +12,8 @@ class PathPlanner(TalosPathPlanner):
         self.root_translation_bounds = [-5, 5, -1.5, 1.5, 0.95, 1.3]
         self.init_problem()
 
-        self.q_init[:3] = [0.16, 0.25, 1.14]
-        self.q_goal[:3] = [1.09, 0.25, 1.14]
+        self.q_init[:3] = [0.18, 0.25, 1.14]
+        self.q_goal[:3] = [1.07, 0.25, 1.14]
 
         self.init_viewer("multicontact/plateforme_surfaces",
                          reduce_sizes=[0.18, 0, 0],

--- a/src/hpp/corbaserver/rbprm/scenarios/hrp2_contact_generator.py
+++ b/src/hpp/corbaserver/rbprm/scenarios/hrp2_contact_generator.py
@@ -9,7 +9,7 @@ class HRP2ContactGenerator(AbstractContactGenerator):
         self.robot_node_name = "hrp2_14"
 
     def load_fullbody(self):
-        from hpp.corbaserver.rbprm.hrp2 import Robot
+        from hrp2_rbprm.hrp2 import Robot
         self.fullbody = Robot()
         self.q_ref = self.fullbody.referenceConfig[::] + [0] * self.path_planner.extra_dof
         self.weight_postural = self.fullbody.postureWeights[::] + [0] * self.path_planner.extra_dof

--- a/src/hpp/corbaserver/rbprm/scenarios/hrp2_path_planner.py
+++ b/src/hpp/corbaserver/rbprm/scenarios/hrp2_path_planner.py
@@ -19,5 +19,5 @@ class HRP2PathPlanner(AbstractPathPlanner):
         self.robot_node_name = "hrp2_trunk_flexible"
 
     def load_rbprm(self):
-        from hpp.corbaserver.rbprm.hrp2_abstract import Robot
+        from hrp2_rbprm.hrp2_abstract import Robot
         self.rbprmBuilder = Robot(client=self.hpp_client, clientRbprm=self.rbprm_client)

--- a/src/hpp/corbaserver/rbprm/scenarios/hrp2_path_planner.py
+++ b/src/hpp/corbaserver/rbprm/scenarios/hrp2_path_planner.py
@@ -2,8 +2,8 @@ from .abstract_path_planner import AbstractPathPlanner
 
 
 class HRP2PathPlanner(AbstractPathPlanner):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, context = None):
+        super().__init__(context)
         # set default bounds to a large workspace on x,y with small interval around reference z value
         self.root_translation_bounds = [-5., 5., -5., 5., 0.5, 0.8]
         # set default used limbs to be both feet
@@ -20,4 +20,4 @@ class HRP2PathPlanner(AbstractPathPlanner):
 
     def load_rbprm(self):
         from hpp.corbaserver.rbprm.hrp2_abstract import Robot
-        self.rbprmBuilder = Robot()
+        self.rbprmBuilder = Robot(client=self.hpp_client, clientRbprm=self.rbprm_client)

--- a/src/hpp/corbaserver/rbprm/scenarios/hyq_contact_generator.py
+++ b/src/hpp/corbaserver/rbprm/scenarios/hyq_contact_generator.py
@@ -23,7 +23,7 @@ class HyqContactGenerator(AbstractContactGenerator):
         self.fullbody.setEndState(self.q_goal, self.end_contacts, normals_end)
 
     def load_fullbody(self):
-        from hpp.corbaserver.rbprm.hyq import Robot
+        from hyq_rbprm.hyq import Robot
         self.fullbody = Robot()
         self.q_ref = self.fullbody.referenceConfig[::] + [0] * self.path_planner.extra_dof
         self.weight_postural = self.fullbody.postureWeights[::] + [0] * self.path_planner.extra_dof

--- a/src/hpp/corbaserver/rbprm/scenarios/hyq_path_planner.py
+++ b/src/hpp/corbaserver/rbprm/scenarios/hyq_path_planner.py
@@ -2,8 +2,8 @@ from .abstract_path_planner import AbstractPathPlanner
 
 
 class HyqPathPlanner(AbstractPathPlanner):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, context = None):
+        super().__init__(context)
         # set default bounds to a large workspace on x,y with small interval around reference z value
         self.root_translation_bounds = [-5., 5., -5., 5., 0.5, 0.75]
         # set default used limbs to be both feet
@@ -20,7 +20,7 @@ class HyqPathPlanner(AbstractPathPlanner):
 
     def load_rbprm(self):
         from hpp.corbaserver.rbprm.hyq_abstract import Robot
-        self.rbprmBuilder = Robot()
+        self.rbprmBuilder = Robot(client=self.hpp_client, clientRbprm=self.rbprm_client)
 
     def set_joints_bounds(self):
         super().set_joints_bounds()

--- a/src/hpp/corbaserver/rbprm/scenarios/hyq_path_planner.py
+++ b/src/hpp/corbaserver/rbprm/scenarios/hyq_path_planner.py
@@ -19,7 +19,7 @@ class HyqPathPlanner(AbstractPathPlanner):
         self.robot_node_name = "hyq_trunk_large"
 
     def load_rbprm(self):
-        from hpp.corbaserver.rbprm.hyq_abstract import Robot
+        from hyq_rbprm.hyq_abstract import Robot
         self.rbprmBuilder = Robot(client=self.hpp_client, clientRbprm=self.rbprm_client)
 
     def set_joints_bounds(self):

--- a/src/hpp/corbaserver/rbprm/scenarios/talos_path_planner.py
+++ b/src/hpp/corbaserver/rbprm/scenarios/talos_path_planner.py
@@ -2,8 +2,8 @@ from .abstract_path_planner import AbstractPathPlanner
 
 
 class TalosPathPlanner(AbstractPathPlanner):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, context = None):
+        super().__init__(context)
         # set default bounds to a large workspace on x,y with small interval around reference z value
         self.root_translation_bounds = [-5., 5., -5., 5., 0.95, 1.05]
         # set default used limbs to be both feet
@@ -20,7 +20,7 @@ class TalosPathPlanner(AbstractPathPlanner):
 
     def load_rbprm(self):
         from talos_rbprm.talos_abstract import Robot
-        self.rbprmBuilder = Robot()
+        self.rbprmBuilder = Robot(client=self.hpp_client, clientRbprm=self.rbprm_client)
 
     def set_joints_bounds(self):
         super().set_joints_bounds()

--- a/src/hpp/corbaserver/rbprm/scenarios/talos_path_planner.py
+++ b/src/hpp/corbaserver/rbprm/scenarios/talos_path_planner.py
@@ -21,6 +21,7 @@ class TalosPathPlanner(AbstractPathPlanner):
     def load_rbprm(self):
         from talos_rbprm.talos_abstract import Robot
         self.rbprmBuilder = Robot(client=self.hpp_client, clientRbprm=self.rbprm_client)
+        self.root_translation_bounds[-2:] = [self.rbprmBuilder.ref_height] * 2
 
     def set_joints_bounds(self):
         super().set_joints_bounds()

--- a/src/hpp/corbaserver/rbprm/tools/constants_and_tools.py
+++ b/src/hpp/corbaserver/rbprm/tools/constants_and_tools.py
@@ -1,0 +1,201 @@
+import numpy as np
+# from hpp.corbaserver.rbprm.hrp2 import Robot as rob
+# from hpp.corbaserver.rbprm.tools.obj_to_constraints import load_obj, as_inequalities, rotate_inequalities
+# from hpp_centroidal_dynamics import *
+# from hpp_spline import *e
+from numpy import array, hstack, identity, matrix, ones, vstack, zeros
+from scipy.spatial import ConvexHull
+
+# import eigenpy
+import cdd
+
+# from hpp_bezier_com_traj import *
+# from qp import solve_lp
+
+Id = matrix([[1., 0., 0.], [0., 1., 0.], [0., 0., 1.]])
+z = array([0., 0., 1.])
+zero3 = zeros(3)
+
+
+def generators(A, b, Aeq=None, beq=None):
+    m = np.hstack([b, -A])
+    matcdd = cdd.Matrix(m)
+    matcdd.rep_type = cdd.RepType.INEQUALITY
+
+    if Aeq is not None:
+        meq = np.hstack([beq, -Aeq])
+        matcdd.extend(meq.tolist(), True)
+
+    H = cdd.Polyhedron(matcdd)
+    g = H.get_generators()
+
+    return [array(g[el][1:]) for el in range(g.row_size)], H
+
+
+def filter(pts):
+    hull = ConvexHull(pts, qhull_options='Q12')
+    return [pts[i] for i in hull.vertices.tolist()]
+
+
+def ineq(pts, canonicalize=False):
+    apts = array(pts)
+    m = np.hstack([ones((apts.shape[0], 1)), apts])
+    matcdd = cdd.Matrix(m)
+    matcdd.rep_type = cdd.RepType.GENERATOR
+    H = cdd.Polyhedron(matcdd)
+    bmA = H.get_inequalities()
+    if canonicalize:
+        bmA.canonicalize()
+    Ares = zeros((bmA.row_size, bmA.col_size - 1))
+    bres = zeros(bmA.row_size)
+    for i in range(bmA.row_size):
+        bmAl = array(bmA[i])
+        Ares[i, :] = -bmAl[1:]
+        bres[i] = bmAl[0]
+    return Ares, bres
+
+
+def ineqQHull(hull):
+    A = hull.equations[:, :-1]
+    b = -hull.equations[:, -1]
+    return A, b
+
+
+def canon(A, b):
+    m = np.hstack([b, -A])
+    matcdd = cdd.Matrix(m)
+    matcdd.rep_type = 1
+    H = cdd.Polyhedron(matcdd)
+    bmA = H.get_inequalities()
+    # bmA.canonicalize()
+    Ares = zeros((bmA.row_size, bmA.col_size - 1))
+    bres = zeros((bmA.row_size, 1))
+    for i in range(bmA.row_size):
+        # print("line ", array(bmA[i]))
+        # print("A ", A[i][:])
+        # print("b ", b[i])
+        bmAl = array(bmA[i])
+        Ares[i, :] = -bmAl[1:]
+        bres[i] = bmAl[0]
+        # print("Ares ",Ares[i,:])
+        # print("bres ",bres[i])
+    return Ares, bres
+
+
+def genPolytope(A, b):
+    pts, H = generators(A, b)
+    apts = array(pts)
+    if len(apts) > 0:
+        hull = ConvexHull(apts)
+        return hull, pts, apts, H
+    return None, None, None, None
+
+
+def convex_hull_ineq(pts):
+    return None
+    """
+    # TODO: what is cData ?
+    m = cData.contactPhase_.getMass()
+    # get 6D polytope
+    (H, h) = ineqFromCdata(cData)
+    #project to the space where aceleration is 0
+    D = zeros((6, 3))
+    D[3:, :] = m * gX
+
+    d = zeros((6, ))
+    d[:3] = -m * g
+
+    A = H.dot(D)
+    b = h.reshape((-1, )) - H.dot(d)
+    #add kinematic polytope
+    (K, k) = (cData.Kin_[0], cData.Kin_[1].reshape(-1, ))
+
+    resA = vstack([A, K])
+    resb = concatenate([b, k]).reshape((-1, 1))
+
+    #DEBUG
+    allpts = generators(resA, resb)[0]
+    error = False
+    for pt in allpts:
+        print("pt ", pt)
+        assert (resA.dot(pt.reshape((-1, 1))) - resb).max() < 0.001, "antecedent point not in End polytope" + str(
+            (resA.dot(pt.reshape((-1, 1))) - resb).max())
+        if (H.dot(w(m, pt).reshape((-1, 1))) - h).max() > 0.001:
+            error = True
+            print("antecedent point not in End polytope" + str((H.dot(w(m, pt).reshape((-1, 1))) - h).max()))
+    assert not error, str(len(allpts))
+
+    return (resA, resb)
+    # return (A, b)
+    # return (vstack([A, K]), None)
+    """
+
+
+def default_transform_from_pos_normal(pos, normal):
+    # print("pos ", pos
+    # print("normal ", normal)
+    f = array([0., 0., 1.])
+    t = array(normal)
+    v = np.cross(f, t)
+    c = np.dot(f, t)
+    if c > 0.99:
+        rot = identity(3)
+    else:
+        # u = v / norm(v)
+        h = (1. - c) / (1. - c**2)
+
+        vx, vy, vz = v
+        rot = array([[c + h * vx**2, h * vx * vy - vz, h * vx * vz + vy],
+                     [h * vx * vy + vz, c + h * vy**2, h * vy * vz - vx],
+                     [h * vx * vz - vy, h * vy * vz + vx, c + h * vz**2]])
+    return vstack([hstack([rot, pos.reshape((-1, 1))]), [0., 0., 0., 1.]])
+
+
+def continuous(h, initpts):
+    dic = {}
+    pts = []
+    for i, pt in enumerate(h.vertices.tolist()):
+        pts += [initpts[pt]]
+        dic[pt] = i
+    faces = []
+    for f in h.simplices:
+        faces += [[dic[idx] + 1 for idx in f]]
+    return pts, faces
+
+
+def hull_to_obj(h, pts, name):
+    pts, faces = continuous(h, pts)
+    f = open(name, "w")
+    # first write points
+    for pt in pts:
+        # print("??")
+        f.write('v ' + str(pt[0]) + ' ' + str(pt[1]) + ' ' + str(pt[2]) + ' \n')
+    f.write('g foo\n')
+    for pt in faces:
+        # print("???")
+        f.write('f ' + str(pt[0]) + ' ' + str(pt[1]) + ' ' + str(pt[2]) + ' \n')
+    f.write('g \n')
+    f.close()
+
+
+# function vertface2obj(v,f,name)
+# % VERTFACE2OBJ Save a set of vertice coordinates and faces as a Wavefront/Alias Obj file
+# % VERTFACE2OBJ(v,f,fname)
+# %     v is a Nx3 matrix of vertex coordinates.
+# %     f is a Mx3 matrix of vertex indices.
+# %     fname is the filename to save the obj file.
+
+# fid = fopen(name,'w');
+
+# for i=1:size(v,1)
+# fprintf(fid,'v %f %f %f\n',v(i,1),v(i,2),v(i,3));
+# end
+
+# fprintf(fid,'g foo\n');
+
+# for i=1:size(f,1);
+# fprintf(fid,'f %d %d %d\n',f(i,1),f(i,2),f(i,3));
+# end
+# fprintf(fid,'g\n');
+
+# fclose(fid);

--- a/src/hpp/corbaserver/rbprm/tools/surfaces_from_path.py
+++ b/src/hpp/corbaserver/rbprm/tools/surfaces_from_path.py
@@ -96,7 +96,7 @@ def getMergedPhases(seqs):
 def computeRootYawAngleBetwwenConfigs(q0, q1):
     quat0 = Quaternion(q0[6], q0[3], q0[4], q0[5])
     quat1 = Quaternion(q1[6], q1[3], q1[4], q1[5])
-    v_angular = np.array(log3(quat0.matrix().dot(quat1.matrix())))
+    v_angular = np.array(log3(quat0.matrix().T.dot(quat1.matrix())))
     #print ("q_prev : ",q0)
     #print ("q      : ",q1)
     #print ("v_angular = ",v_angular)

--- a/src/rbprmbuilder.impl.cc
+++ b/src/rbprmbuilder.impl.cc
@@ -82,14 +82,16 @@ hpp::floatSeq vectorToFloatseq(const hpp::core::vector_t& input) {
   return floats;
 }
 
-void RbprmBuilder::loadRobotRomModel(const char* robotName, const char* rootJointType, const char* packageName,
-                                     const char* modelName, const char* urdfSuffix,
-                                     const char* srdfSuffix) throw(hpp::Error) {
+void RbprmBuilder::loadRobotRomModel(const char* robotName,
+                                     const char* rootJointType,
+                                     const char* urdfName) throw(hpp::Error) {
   try {
     hpp::pinocchio::DevicePtr_t romDevice = pinocchio::Device::create(robotName);
     romDevices_.insert(std::make_pair(robotName, romDevice));
-    hpp::pinocchio::urdf::loadRobotModel(romDevice, std::string(rootJointType), std::string(packageName),
-                                         std::string(modelName), std::string(urdfSuffix), std::string(srdfSuffix));
+    hpp::pinocchio::urdf::loadModel(romDevice, 0, "",
+                                         std::string (rootJointType),
+                                         std::string (urdfName),
+                                         std::string ());
   } catch (const std::exception& exc) {
     hppDout(error, exc.what());
     throw hpp::Error(exc.what());
@@ -97,9 +99,10 @@ void RbprmBuilder::loadRobotRomModel(const char* robotName, const char* rootJoin
   romLoaded_ = true;
 }
 
-void RbprmBuilder::loadRobotCompleteModel(const char* robotName, const char* rootJointType, const char* packageName,
-                                          const char* modelName, const char* urdfSuffix,
-                                          const char* srdfSuffix) throw(hpp::Error) {
+void RbprmBuilder::loadRobotCompleteModel(const char* robotName,
+                                          const char* rootJointType,
+                                          const char* urdfName,
+                                          const char* srdfName) throw(hpp::Error) {
   if (!romLoaded_) {
     std::string err("Rom must be loaded before loading complete model");
     hppDout(error, err);
@@ -107,8 +110,10 @@ void RbprmBuilder::loadRobotCompleteModel(const char* robotName, const char* roo
   }
   try {
     hpp::pinocchio::RbPrmDevicePtr_t device = hpp::pinocchio::RbPrmDevice::create(robotName, romDevices_);
-    hpp::pinocchio::urdf::loadRobotModel(device, std::string(rootJointType), std::string(packageName),
-                                         std::string(modelName), std::string(urdfSuffix), std::string(srdfSuffix));
+    hpp::pinocchio::urdf::loadModel(device, 0, "",
+                                         std::string (rootJointType),
+                                         std::string (urdfName),
+                                         std::string (srdfName));
     // Add device to the planner
     problemSolver()->robot(device);
     problemSolver()->robot()->controlComputation(flag);

--- a/src/rbprmbuilder.impl.cc
+++ b/src/rbprmbuilder.impl.cc
@@ -118,13 +118,17 @@ void RbprmBuilder::loadRobotCompleteModel(const char* robotName, const char* roo
   }
 }
 
-void RbprmBuilder::loadFullBodyRobot(const char* robotName, const char* rootJointType, const char* packageName,
-                                     const char* modelName, const char* urdfSuffix, const char* srdfSuffix,
+void RbprmBuilder::loadFullBodyRobot(const char* robotName,
+                                     const char* rootJointType,
+                                     const char* urdfName,
+                                     const char* srdfName,
                                      const char* selectedProblem) throw(hpp::Error) {
   try {
     hpp::pinocchio::DevicePtr_t device = pinocchio::Device::create(robotName);
-    hpp::pinocchio::urdf::loadRobotModel(device, std::string(rootJointType), std::string(packageName),
-                                         std::string(modelName), std::string(urdfSuffix), std::string(srdfSuffix));
+    hpp::pinocchio::urdf::loadModel(device, 0, "",
+                                         std::string (rootJointType),
+                                         std::string (urdfName),
+                                         std::string (srdfName));
     std::string name(selectedProblem);
     fullBodyLoaded_ = true;
     fullBodyMap_.map_[name] = rbprm::RbPrmFullBody::create(device);

--- a/src/rbprmbuilder.impl.hh
+++ b/src/rbprmbuilder.impl.hh
@@ -165,8 +165,10 @@ class RbprmBuilder : public virtual POA_hpp::corbaserver::rbprm::RbprmBuilder {
                                       const char* modelName, const char* urdfSuffix,
                                       const char* srdfSuffix) throw(hpp::Error);
 
-  virtual void loadFullBodyRobot(const char* robotName, const char* rootJointType, const char* packageName,
-                                 const char* modelName, const char* urdfSuffix, const char* srdfSuffix,
+  virtual void loadFullBodyRobot(const char* robotName,
+                                 const char* rootJointType,
+                                 const char* urdfName,
+                                 const char* srdfName,
                                  const char* selectedProblem) throw(hpp::Error);
 
   virtual void loadFullBodyRobotFromExistingRobot() throw(hpp::Error);

--- a/src/rbprmbuilder.impl.hh
+++ b/src/rbprmbuilder.impl.hh
@@ -157,13 +157,14 @@ class RbprmBuilder : public virtual POA_hpp::corbaserver::rbprm::RbprmBuilder {
 
   void setServer(Server* server) { server_ = server; }
 
-  virtual void loadRobotRomModel(const char* robotName, const char* rootJointType, const char* packageName,
-                                 const char* modelName, const char* urdfSuffix,
-                                 const char* srdfSuffix) throw(hpp::Error);
+  virtual void loadRobotRomModel(const char* robotName,
+                                 const char* rootJointType,
+                                 const char* urdfName) throw(hpp::Error);
 
-  virtual void loadRobotCompleteModel(const char* robotName, const char* rootJointType, const char* packageName,
-                                      const char* modelName, const char* urdfSuffix,
-                                      const char* srdfSuffix) throw(hpp::Error);
+  virtual void loadRobotCompleteModel(const char* robotName,
+                                      const char* rootJointType,
+                                      const char* urdfName,
+                                      const char* srdfName) throw(hpp::Error);
 
   virtual void loadFullBodyRobot(const char* robotName,
                                  const char* rootJointType,

--- a/tests/python/test_rbprm_state_3d.py
+++ b/tests/python/test_rbprm_state_3d.py
@@ -2,7 +2,7 @@
 # Authors: Pierre Fernbach <pfernbac@laas.fr>
 import unittest
 
-from hpp.corbaserver.rbprm.hyq import Robot
+from hyq_rbprm.hyq import Robot
 from hpp.corbaserver.rbprm.rbprmstate import State, StateHelper
 
 from hpp.corbaserver.rbprm.utils import ServerManager

--- a/tests/python/test_talos_walk_path.py
+++ b/tests/python/test_talos_walk_path.py
@@ -19,12 +19,11 @@ class TestTalosWalkPath(unittest.TestCase):
             planner = PathPlanner()
             planner.run()
             ps = planner.ps
-            self.assertEqual(ps.numberPaths(), 2)
-            self.assertEqual(ps.pathLength(0), ps.pathLength(1))
-            self.assertTrue(ps.pathLength(1) > 6.)
-            self.assertTrue(ps.pathLength(1) < 7.)
-            self.assertEqual(planner.q_init, ps.configAtParam(1, 0))
-            self.assertEqual(planner.q_goal, ps.configAtParam(1, ps.pathLength(1)))
+            self.assertEqual(ps.numberPaths(), 1)
+            self.assertTrue(ps.pathLength(0) > 6.)
+            self.assertTrue(ps.pathLength(0) < 7.)
+            self.assertEqual(planner.q_init, ps.configAtParam(0, 0))
+            self.assertEqual(planner.q_goal, ps.configAtParam(0, ps.pathLength(0)))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Main changes

* Update relative to change in hpp-corbaserver: the `load...` methods now take a full name of the urdf and srdf file, which can contains "package://"
* AbstractPathPlanner can now take a `context` optional argument, used to define a corba context
* Update all scripts to the change of path of the python Robot classes.


## Other changes: 
* Add matlab scripts to generate ROMs, this scripts were previously in the package hpp-rbprm-robot-data
* Add constant_and_tools.py script in tools, this script was previously in the package hpp-rbprm-robot-data
* surface_from_path: fix issue related to numpy array/matrix in the max_yaw angle constraint
* talos_path_planner: By default, set the root translation on the z axis to be the reference height
* AbstractPathPlanner: solve() now take an optionnal argument to display the roadmap iteratively during it's construction


