### PR TITLE
add missing include

### DIFF
--- a/src/rbprmbuilder.impl.cc
+++ b/src/rbprmbuilder.impl.cc
@@ -50,6 +50,7 @@
 #include <hpp/rbprm/contact_generation/reachability.hh>
 #include <hpp/pinocchio/urdf/util.hh>
 #include "hpp/rbprm/utils/algorithms.h"
+#include <boost/bind.hpp>
 
 #ifdef PROFILE
 #include "hpp/rbprm/rbprm-profiler.hh"


### PR DESCRIPTION
I guess this was included in another header, but it is not anymore:
```
…/src/rbprmbuilder.impl.cc:3109:14: error: 'bind' is not a member of 'boost'
boost::bind(&BindShooter::createDynamicPathValidation, boost::ref(bindShooter_), _1, _2));
^~~~
```