### PR TITLE
fix _initOrb call

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0'?>
 <package format='2'>
     <name>hpp-rbprm-corba</name>
-    <version>4.11.0</version>
+    <version>4.12.0</version>
     <description>RB-PRM planner for HPP</description>
 
     <maintainer email='guilhem.saurel@laas.fr'>Guilhem Saurel</maintainer>

--- a/src/hpp/corbaserver/rbprm/client.py
+++ b/src/hpp/corbaserver/rbprm/client.py
@@ -30,7 +30,7 @@ class Client(_Parent):
         'builder': RbprmBuilder,
     }
 
-    def __init__(self, url=None, context="corbaserver", port=13331):
+    def __init__(self, url=None, context="corbaserver", port=None):
         """
     Initialize CORBA and create default clients.
     :param url: URL in the IOR, corbaloc, corbalocs, and corbanames formats.

--- a/src/hpp/corbaserver/rbprm/client.py
+++ b/src/hpp/corbaserver/rbprm/client.py
@@ -37,7 +37,7 @@ class Client(_Parent):
                 For a remote corba server, use
                 url = "corbaloc:iiop:<host>:<port>/NameService"
     """
-        self._initOrb(url, port)
+        self._initOrb(url, port=port)
         self._makeClients("rbprm", self.defaultClients, context)
 
         # self.builder is created by self._makeClients

--- a/tests/python/test_talos_walk_contacts.py
+++ b/tests/python/test_talos_walk_contacts.py
@@ -12,13 +12,12 @@ class TestTalosWalkContact(unittest.TestCase):
     def test_talos_walk_contacts(self):
         with ServerManager('hpp-rbprm-server'):
             module_scenario = import_module(PATH + ".talos_flatGround")
-            if not hasattr(module_scenario, 'ContactGenerator'):
-                self.assertTrue(False)
+            self.assertTrue(hasattr(module_scenario, 'ContactGenerator'))
             ContactGenerator = getattr(module_scenario, 'ContactGenerator')
             cg = ContactGenerator()
             cg.run()
-            self.assertTrue(len(cg.configs) > 5)
-            self.assertTrue(len(cg.configs) < 10)
+            self.assertGreater(len(cg.configs), 5)
+            self.assertLess(len(cg.configs), 10)
             self.assertEqual(cg.q_init, cg.configs[0])
             self.assertEqual(cg.q_goal, cg.configs[-1])
 

--- a/tests/python/test_talos_walk_path.py
+++ b/tests/python/test_talos_walk_path.py
@@ -13,15 +13,14 @@ class TestTalosWalkPath(unittest.TestCase):
     def test_talos_walk_path(self):
         with ServerManager('hpp-rbprm-server'):
             module_scenario = import_module(PATH + ".talos_flatGround_path")
-            if not hasattr(module_scenario, 'PathPlanner'):
-                self.assertTrue(False)
+            self.assertTrue(hasattr(module_scenario, 'PathPlanner'))
             PathPlanner = getattr(module_scenario, 'PathPlanner')
             planner = PathPlanner()
             planner.run()
             ps = planner.ps
             self.assertEqual(ps.numberPaths(), 1)
-            self.assertTrue(ps.pathLength(0) > 6.)
-            self.assertTrue(ps.pathLength(0) < 7.)
+            self.assertGreater(ps.pathLength(0), 6.)
+            self.assertLess(ps.pathLength(0), 7.)
             self.assertEqual(planner.q_init, ps.configAtParam(0, 0))
             self.assertEqual(planner.q_goal, ps.configAtParam(0, ps.pathLength(0)))
 


### PR DESCRIPTION
https://github.com/humanoid-path-planner/hpp-corbaserver/blob/f3e36a0ef25bf793fef1e60144c9d94945be57d5/src/hpp/corbaserver/client.py#L97

passing port by argument order is wrong here, as it will be understood as host.

thanks @JasonChmn for the debug